### PR TITLE
MotionPlanner for Multi-Motor Control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ add_executable( ${PROJECT_NAME}
             src/Log.cpp
             src/StepperDriver.cpp
             src/TB67S128FTG.cpp
-            src/StepperMotor.cpp )
+            src/StepperMotor.cpp
+            src/MotionPlanner.cpp )
 
 pico_set_program_name(${PROJECT_NAME} "kiichigoFirmware")
 pico_set_program_version(${PROJECT_NAME} "0.1")

--- a/README.md
+++ b/README.md
@@ -106,6 +106,53 @@ int main()
 }
 ```
 
+Concurrent Multi-motor operation the MotionPlanner package
+``` cpp
+#include <stdio.h>
+#include "pico/stdlib.h"
+
+#include "Log.h"
+#include "TB67S128FTG.h"
+#include "StepperMotor.h"
+#include "MotionPlanner.h"
+
+MotionConfig config; //struct for configuring the motors to be used in the MotionPlanner object
+
+int main()
+{
+    stdio_init_all();
+
+    // Wait for USB serial to be connected
+    while (!stdio_usb_connected()) {
+        sleep_ms(100);
+    }
+
+    // Print a message to the USB serial
+    printf("USB Serial connected!\n");
+
+    TB67S128FTG stepper_driver1(0, 1, 2, 3, 4, 5, StepperDriver::StepMode::HALF);
+    StepperMotor stepper1("x", stepper_driver1, 200, 100);
+
+    config.stepper_motors={&stepper1}; // declare all stepper motors to be controlled by the MotionPlanner object in the the MotionConfig struct;
+
+    MotionPlanner stepper_controller(config); // instantiate the MotionPlanner
+
+
+    stepper_controller.loop_forever(); //continous action request operation through serial Monitor, using the FIFO principle (this is blocking)
+    /*Serial Command List: 
+    
+        1. MOVE <motorlabel1>,<revolutions> <motorlabel2><revolutions> ...: This command sets the number of revolutions that each motor in the motion planner should make, currently only accepts int (ex. "MOVE x,100 y,-100 z,10")
+    */
+
+    printf("Done!\n");
+
+    return 0;
+}
+
+```
+
+
+
 
 ## Feedback
 All kinds of feedback and contributions are welcome.
@@ -124,3 +171,12 @@ All kinds of feedback and contributions are welcome.
 - [TB67S128FTG](https://www.pololu.com/product/2998) Motor Driver Support added inherets from StepperDriver.
 - StepperMotor library added to abstract StepperDriver controls, includes motor specific functionalities such as revolution control, position tracking. Dependent on StepperDriver class. 
 - Logging module added to simplify displaying various levels of messages on Serial Monitor.
+- Multi-Motor Control with the MotionPlanner Package.
+    - Current Functionality is to receive commands from Serial USB 
+    - Concurrent operation with the loop_forever() method (blocking)
+    - USB Serial Command list:
+        1. MOVE <`motorlabel1`>,<`revolutions`> <`motorlabel2`><`revolutions`> ... : This command sets the number of revolutions that each motor in the motion planner should make, currently only accepts int (ex. "MOVE x,100 y,-100 z,10")
+        2. SPEED (in progress)
+        3. STANDBY (in progress)
+        4. POSITION (in progress)
+        4. HOME (in progress)

--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -3,6 +3,13 @@
 #include "StepperMotor.h"
 #include <vector>
 #include <unordered_map>
+#include <queue>
+#include <functional>
+#include <sstream>
+#include <string.h>
+
+
+
 
 
 #define BUFFER_SIZE 64
@@ -17,9 +24,9 @@ class MotionPlanner{
 
         MotionPlanner(const MotionConfig& config);
 
-        bool start_action();
+        std::string read_serial_line();
 
-        void update_action();
+        bool update_action();
 
         void loop_forever();
 
@@ -27,15 +34,17 @@ class MotionPlanner{
 
         void request_action();
 
-        void load_action_queue();
-
-        void process_command(const char* line);
+        // void process_command(const char* line);
     
     private:
-        bool action_queue_;
+
+        void register_commands_();
+
+
+        std::queue<std::function<void()>> action_queue_;
         char input_buffer[BUFFER_SIZE];
-        // std::vector<StepperMotor*> stepper_motors_;
         std::unordered_map<std::string, StepperMotor*> stepper_motors_;
+        std::unordered_map<std::string, std::function<void(std::istringstream&)>> command_handlers_;
         
 
 };

--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -9,9 +9,6 @@
 #include <string.h>
 
 
-
-
-
 #define BUFFER_SIZE 64
 
 struct MotionConfig{
@@ -26,23 +23,19 @@ class MotionPlanner{
 
         std::string read_serial_line();
 
-        bool update_action();
+        bool update_actions();
 
         void loop_forever();
 
-        bool stop();
-
         void request_action();
-
-        // void process_command(const char* line);
     
     private:
 
         void register_commands_();
+        bool is_integer_(const std::string& s);
 
 
         std::queue<std::function<void()>> action_queue_;
-        char input_buffer[BUFFER_SIZE];
         std::unordered_map<std::string, StepperMotor*> stepper_motors_;
         std::unordered_map<std::string, std::function<void(std::istringstream&)>> command_handlers_;
         

--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -8,9 +8,6 @@
 #include <sstream>
 #include <string.h>
 
-
-#define BUFFER_SIZE 64
-
 struct MotionConfig{
     std::vector<StepperMotor*> stepper_motors={};
 };

--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -1,0 +1,46 @@
+#ifndef MotionPlanner_H
+#define MotionPlanner_H
+#include "StepperMotor.h"
+#include <vector>
+#include <unordered_map>
+
+
+#define BUFFER_SIZE 64
+
+struct MotionConfig{
+    std::vector<StepperMotor*> stepper_motors={};
+};
+
+
+class MotionPlanner{
+    public:
+
+        MotionPlanner(const MotionConfig& config);
+
+        bool start_action();
+
+        void update_action();
+
+        void loop_forever();
+
+        bool stop();
+
+        void request_action();
+
+        void load_action_queue();
+
+        void process_command(const char* line);
+    
+    private:
+        bool action_queue_;
+        char input_buffer[BUFFER_SIZE];
+        // std::vector<StepperMotor*> stepper_motors_;
+        std::unordered_map<std::string, StepperMotor*> stepper_motors_;
+        
+
+};
+
+
+
+
+#endif

--- a/include/StepperMotor.h
+++ b/include/StepperMotor.h
@@ -4,6 +4,7 @@
 #include "StepperDriver.h"
 #include <array>
 #include <tuple>
+#include <string>
 
 
 
@@ -20,7 +21,7 @@ class StepperMotor {
             128      // ONE_128
         }};
 
-        StepperMotor(const char* label,
+        StepperMotor(std::string label,
                      StepperDriver& driver,
                      uint32_t steps_per_rev,
                      uint32_t default_speed=200); //in rpms
@@ -33,8 +34,10 @@ class StepperMotor {
         void set_standbyMode(bool);
         bool active();
 
+        const std::string& label() const;
+
     private:
-        const char* label_;
+        std::string label_;
         uint32_t steps_per_rev_, speed_;
         StepperDriver& driver_;
         int32_t position_step_;

--- a/include/StepperMotor.h
+++ b/include/StepperMotor.h
@@ -24,7 +24,7 @@ class StepperMotor {
         StepperMotor(std::string label,
                      StepperDriver& driver,
                      uint32_t steps_per_rev,
-                     uint32_t default_speed=200); //in rpms
+                     uint32_t default_speed=200); //in rpm
 
         void revolve(int32_t revolutions=1);
         void set_speed(uint32_t rpm=200);

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -1,10 +1,13 @@
 #include "MotionPlanner.h"
 #include "Log.h"
 #include <stdio.h>
-#include <string.h>
+#include <algorithm>
+#include <cctype>
 
 
 MotionPlanner::MotionPlanner(const MotionConfig& config) {
+
+    register_commands_();
     
     for (StepperMotor* stepper : config.stepper_motors){
         stepper_motors_[stepper->label()] = stepper; 
@@ -12,55 +15,118 @@ MotionPlanner::MotionPlanner(const MotionConfig& config) {
 
 }
 
-void MotionPlanner::process_command(const char* line){
-    char command[16];
-    int value;
 
-    if (sscanf(line, "%15s %d", command, &value) == 2) {
-        printf("Parsed command: [%s] with value: %d\n", command, value);
+std::string MotionPlanner::read_serial_line() {
+    std::string buffer;
+    int c;
 
-        if (strcmp(command, "MOVE") == 0) {
-            // Do something like: motor.revolve(value);
-            printf("➡️  Executing MOVE %d\n", value);
-        } else {
-            printf("⚠️  Unknown command: %s\n", command);
+    while (true) {
+        c = getchar_timeout_us(0);  // non-blocking read
+
+        if (c == PICO_ERROR_TIMEOUT) {
+            break;  // no input, return what we have (or nothing)
         }
 
-    } else {
-        printf("⚠️  Could not parse input: %s\n", line);
+        if (c == '\r') continue;  // ignore carriage return
+
+        if (c == '\n') {
+            return buffer;  // full line received
+        }
+
+        buffer += static_cast<char>(c);
     }
 
+    return "";  // nothing read
 }
 
 
 void MotionPlanner::request_action(){
-    int c = getchar_timeout_us(0);
+
+    std::string line = read_serial_line();
+
+    if (!line.empty()) {
+        std::string command;
+        std::istringstream iss(line);     
+        iss >> command;
+
+        std::transform(command.begin(), command.end(), command.begin(), ::toupper);
+
+        if(command_handlers_.contains(command)){
+            
+            command_handlers_[command](iss);
+
+        }else{
+            LOG_WARN("unknown command: %s\n", command.c_str());
+        }
+
+
+
     
-    if (c != PICO_ERROR_TIMEOUT) {
-            printf("Received: %c\n", c);
+
+
+
     }
+   
+
+
+
     
 }
+
+bool MotionPlanner::update_action(){
+
+}
+
 
 void MotionPlanner::loop_forever(){
 
-while (true){
+    request_action();
 
-    bool active = load_action_queue();
+    while(!action_queue_.empty()){
 
-    start_action();
+        action_queue_.pop();
 
-    while(active){
-        request_action();
-        update_action();
+        bool flag = true;
+        while(flag){
+
+            request_action();
+
+            flag = update_action();
+
+        }
+
 
 
     }
 
-    
-    if
-
-
 }
+
+
+
+void MotionPlanner::register_commands_(){
+
+    command_handlers_["MOVE"] = [&](std::istringstream& iss) {
+
+        bool valid = false;
+        std::string token;
+
+
+        while (iss >> token){
+
+            if (token.length() <2 ) continue;
+
+            char label = std::tolower(token[0]);
+            std::string value_str = token.substr(1);
+
+
+
+        }
+
+    };
+
+    command_handlers_["SPEED"] = [&](std::istringstream& iss) {
+        
+    };
+
 
 }

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -6,12 +6,12 @@
 
 
 MotionPlanner::MotionPlanner(const MotionConfig& config) {
-
-    register_commands_();
     
     for (StepperMotor* stepper : config.stepper_motors){
         stepper_motors_[stepper->label()] = stepper; 
     }
+
+    register_commands_();
 
 }
 
@@ -51,7 +51,7 @@ void MotionPlanner::request_action(){
 
         std::transform(command.begin(), command.end(), command.begin(), ::toupper);
 
-        if(command_handlers_.contains(command)){
+        if(command_handlers_.find(command) != command_handlers_.end()){
             
             command_handlers_[command](iss);
 
@@ -59,74 +59,128 @@ void MotionPlanner::request_action(){
             LOG_WARN("unknown command: %s\n", command.c_str());
         }
 
-
-
-    
-
-
-
     }
-   
-
-
-
     
 }
 
-bool MotionPlanner::update_action(){
+bool MotionPlanner::update_actions(){
+
+    bool active_flag=false;
+
+    for (const auto&[label, motor]: stepper_motors_){
+        if(motor->active()){
+            motor->step();
+            active_flag=true;
+        }
+    }
+
+    return active_flag;
 
 }
 
 
 void MotionPlanner::loop_forever(){
+    
+    while (true){
+    
+        request_action();
 
-    request_action();
+        while(!action_queue_.empty()){
 
-    while(!action_queue_.empty()){
+            auto action = action_queue_.front();
+            action_queue_.pop();
+            action();
 
-        action_queue_.pop();
+            
+            while(true){
 
-        bool flag = true;
-        while(flag){
+                request_action();
 
-            request_action();
+                bool busy = update_actions();
 
-            flag = update_action();
+                if(!busy){break;}
+
+            }
 
         }
 
-
-
+        sleep_ms(1);
+        
     }
 
 }
 
-
+/*Private Methods and  Helper functions*/
 
 void MotionPlanner::register_commands_(){
 
     command_handlers_["MOVE"] = [&](std::istringstream& iss) {
+        /*This command parses commands from serial with this format:
+            "MOVE X,10 Y,100 Z,-100"
+        */
 
-        bool valid = false;
         std::string token;
+        std::unordered_map<std::string, int32_t> command_dict;
 
 
         while (iss >> token){
 
-            if (token.length() <2 ) continue;
+            if (token.length() <2 ) {continue;}
 
-            char label = std::tolower(token[0]);
-            std::string value_str = token.substr(1);
+            std::istringstream command_stream(token);
+            std::string label, value_str;
+            
 
+            if(std::getline(command_stream, label, ',') && std::getline(command_stream, value_str)){
 
+                if(stepper_motors_.find(label) == stepper_motors_.end()){
+                    LOG_WARN("Unknown motor: %s\n",label.c_str());
+                    continue;
+                }
+
+                if (value_str.empty() || (!is_integer_(value_str))) {
+                    LOG_WARN("Invalid input: %s\n", value_str.c_str());
+                    continue;
+                }
+
+                int32_t value = std::stoi(value_str);
+                command_dict[label] = value;
+
+            }else{
+                LOG_WARN("Invalid token: %s\n", token.c_str());
+                continue;
+            }
 
         }
 
+        if(!command_dict.empty()){
+
+            action_queue_.push([command_dict, this](){
+
+                for(const auto& [label, value] : command_dict){
+
+                    stepper_motors_[label]->revolve(value);
+                    LOG_INFO("Added to Queue: MOVE %s -> %d revolutions\n", label.c_str(), value);
+
+                }
+            });
+        }else{
+            LOG_WARN("No valid actions in MOVE command\n");
+        }
+
+
     };
 
-    command_handlers_["SPEED"] = [&](std::istringstream& iss) {
-        
-    };
+    // command_handlers_["SPEED"] = [&](std::istringstream& iss) {
+
+    // };
 
 
+}
+
+
+bool MotionPlanner::is_integer_(const std::string& s) {
+    if (s.empty()) return false;
+    size_t start = (s[0] == '-' ? 1 : 0);
+    return std::all_of(s.begin() + start, s.end(), ::isdigit);
 }

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -1,0 +1,66 @@
+#include "MotionPlanner.h"
+#include "Log.h"
+#include <stdio.h>
+#include <string.h>
+
+
+MotionPlanner::MotionPlanner(const MotionConfig& config) {
+    
+    for (StepperMotor* stepper : config.stepper_motors){
+        stepper_motors_[stepper->label()] = stepper; 
+    }
+
+}
+
+void MotionPlanner::process_command(const char* line){
+    char command[16];
+    int value;
+
+    if (sscanf(line, "%15s %d", command, &value) == 2) {
+        printf("Parsed command: [%s] with value: %d\n", command, value);
+
+        if (strcmp(command, "MOVE") == 0) {
+            // Do something like: motor.revolve(value);
+            printf("➡️  Executing MOVE %d\n", value);
+        } else {
+            printf("⚠️  Unknown command: %s\n", command);
+        }
+
+    } else {
+        printf("⚠️  Could not parse input: %s\n", line);
+    }
+
+}
+
+
+void MotionPlanner::request_action(){
+    int c = getchar_timeout_us(0);
+    
+    if (c != PICO_ERROR_TIMEOUT) {
+            printf("Received: %c\n", c);
+    }
+    
+}
+
+void MotionPlanner::loop_forever(){
+
+while (true){
+
+    bool active = load_action_queue();
+
+    start_action();
+
+    while(active){
+        request_action();
+        update_action();
+
+
+    }
+
+    
+    if
+
+
+}
+
+}

--- a/src/Scheduler/Scheduler.cpp
+++ b/src/Scheduler/Scheduler.cpp
@@ -1,2 +1,0 @@
-#include "Scheduler/Scheduler.h"
-#include "Log.h"

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 
 
-StepperMotor::StepperMotor (const char* label,
+StepperMotor::StepperMotor (std::string label,
                             StepperDriver &driver,
                             uint32_t steps_per_rev,
                             uint32_t default_speed) : 
@@ -19,7 +19,7 @@ StepperMotor::StepperMotor (const char* label,
     set_speed(default_speed);
     update_position();
 
-    LOG_DEBUG("%s Defaults set: StepMode Multiplier- %d, steps per revolution- %d, \n", label_, modeMultiplier, steps_per_rev_);
+    LOG_DEBUG("%s Defaults set: StepMode Multiplier- %d, steps per revolution- %d, \n", label_.c_str(), modeMultiplier, steps_per_rev_);
 
 
 }
@@ -29,12 +29,12 @@ void StepperMotor::revolve(int32_t revolutions){
     bool direction = revolutions>=0 ? true:false;
     driver_.set_direction(direction);
     
-    LOG_DEBUG("%s direction set to: %s\n", label_, direction ? "CW" : "CCW");
+    LOG_DEBUG("%s direction set to: %s\n", label_.c_str(), direction ? "CW" : "CCW");
     
     uint32_t steps = std::abs(revolutions)*steps_per_rev_;
     driver_.step_for(steps);
     
-    LOG_DEBUG("%s set for: %d revolutions \n", label_, std::abs(revolutions));
+    LOG_DEBUG("%s set for: %d revolutions \n", label_.c_str(), std::abs(revolutions));
 
 }
 
@@ -47,7 +47,7 @@ void StepperMotor::set_speed(uint32_t rpm){
 
     driver_.set_pulse_interval(pulse_interval);
 
-    LOG_DEBUG("%s Speed set to: %d rpm(%d us pulse inteval)\n", label_, rpm, pulse_interval);   
+    LOG_DEBUG("%s Speed set to: %d rpm(%d us pulse inteval)\n", label_.c_str(), rpm, pulse_interval);   
 
 }
 
@@ -55,7 +55,7 @@ std::tuple<int32_t, double> StepperMotor::update_position(){
     position_step_ = driver_.get_step_tracker();
     position_revolutions_ = static_cast<double>(position_step_)/static_cast<double>(steps_per_rev_);
 
-    LOG_DEBUG("%s Position: %d steps (%.2f revolutions) \n", label_, position_step_, position_revolutions_);
+    LOG_DEBUG("%s Position: %d steps (%.2f revolutions) \n", label_.c_str(), position_step_, position_revolutions_);
 
     return std::make_tuple(position_step_,position_revolutions_);  
 }
@@ -65,13 +65,13 @@ void StepperMotor::home(){
     driver_.home();
     update_position();
 
-    LOG_DEBUG("%s HOME HIT! Position reset to: %d steps (%.2f revolutions) \n", label_, position_step_, position_revolutions_);   
+    LOG_DEBUG("%s HOME HIT! Position reset to: %d steps (%.2f revolutions) \n", label_.c_str(), position_step_, position_revolutions_);   
 
 }
 
 void StepperMotor::set_standbyMode(bool active){
     driver_.set_standbyMode(active);
-    LOG_DEBUG("%s Standby Mode %s", label_, active ?"enabled":"disabled");   
+    LOG_DEBUG("%s Standby Mode %s", label_.c_str(), active ?"enabled":"disabled");   
 
 }
 
@@ -88,3 +88,7 @@ bool StepperMotor::step(){
 
     return pulse_flag;
 }
+
+const std::string& StepperMotor::label() const{
+    return label_;
+};

--- a/src/kiichigoFirmware.cpp
+++ b/src/kiichigoFirmware.cpp
@@ -32,33 +32,6 @@ int main()
 
     stepper_controller.loop_forever(); //this is blocking
 
-
-
-    // stepper1.revolve(-5);
-
-    // while (stepper1.active()) {
-    //     stepper1.step();
-    // }
-
-    // stepper1.revolve(-5);
-
-    // while (stepper1.active()) {
-    //     stepper1.step();
-    // }
-
-    // stepper1.home();
-    // stepper1.set_speed(200);
-    // stepper1.revolve(10);
-
-    // while (stepper1.active()) {
-    //     stepper1.step();
-    // }
-
-    // stepper1.set_standbyMode(true);
-
-    // while (true){
-    // }
-
     printf("Done!\n");
 
     return 0;

--- a/src/kiichigoFirmware.cpp
+++ b/src/kiichigoFirmware.cpp
@@ -26,30 +26,38 @@ int main()
     config.stepper_motors={&stepper1};
 
 
-    stepper1.revolve(-5);
 
-    while (stepper1.active()) {
-        stepper1.step();
-    }
+    MotionPlanner stepper_controller(config);
 
-    stepper1.revolve(-5);
 
-    while (stepper1.active()) {
-        stepper1.step();
-    }
+    stepper_controller.loop_forever(); //this is blocking
 
-    stepper1.home();
-    stepper1.set_speed(200);
-    stepper1.revolve(10);
 
-    while (stepper1.active()) {
-        stepper1.step();
-    }
 
-    stepper1.set_standbyMode(true);
+    // stepper1.revolve(-5);
 
-    while (true){
-    }
+    // while (stepper1.active()) {
+    //     stepper1.step();
+    // }
+
+    // stepper1.revolve(-5);
+
+    // while (stepper1.active()) {
+    //     stepper1.step();
+    // }
+
+    // stepper1.home();
+    // stepper1.set_speed(200);
+    // stepper1.revolve(10);
+
+    // while (stepper1.active()) {
+    //     stepper1.step();
+    // }
+
+    // stepper1.set_standbyMode(true);
+
+    // while (true){
+    // }
 
     printf("Done!\n");
 

--- a/src/kiichigoFirmware.cpp
+++ b/src/kiichigoFirmware.cpp
@@ -4,7 +4,9 @@
 #include "Log.h"
 #include "TB67S128FTG.h"
 #include "StepperMotor.h"
-// #include "Scheduler.h"
+#include "MotionPlanner.h"
+
+MotionConfig config;
 
 int main()
 {
@@ -20,6 +22,9 @@ int main()
 
     TB67S128FTG stepper_driver1(0, 1, 2, 3, 4, 5, StepperDriver::StepMode::HALF);
     StepperMotor stepper1("x-axis", stepper_driver1, 200, 100);
+
+    config.stepper_motors={&stepper1};
+
 
     stepper1.revolve(-5);
 

--- a/src/kiichigoFirmware.cpp
+++ b/src/kiichigoFirmware.cpp
@@ -21,7 +21,7 @@ int main()
     printf("USB Serial connected!\n");
 
     TB67S128FTG stepper_driver1(0, 1, 2, 3, 4, 5, StepperDriver::StepMode::HALF);
-    StepperMotor stepper1("x-axis", stepper_driver1, 200, 100);
+    StepperMotor stepper1("x", stepper_driver1, 200, 100);
 
     config.stepper_motors={&stepper1};
 


### PR DESCRIPTION
- Multi-Motor Control with the MotionPlanner Package.
    - Current Functionality is to receive commands from Serial USB 
    - Concurrent operation with the loop_forever() method (blocking)
    - USB Serial Command list:
        1. MOVE <`motorlabel1`>,<`revolutions`> <`motorlabel2`><`revolutions`> ... : This command sets the number of revolutions that each motor in the motion planner should make, currently only accepts int (ex. "MOVE x,100 y,-100 z,10")
        2. SPEED (in progress)
        3. STANDBY (in progress)
        4. POSITION (in progress)
        4. HOME (in progress)