### PR TITLE
Adding more commands and fixes for  logging and updating position during stanby mode and accept double for revolve function

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ int main()
     /*Serial Command List: 
     
         1. MOVE <motorlabel1>,<revolutions> <motorlabel2><revolutions> ...: This command sets the number of revolutions that each motor in the motion planner should make, currently only accepts int (ex. "MOVE x,100 y,-100 z,10")
+        
+        2. SPEED <`motorlabel1`>,<`rpm`> <`motorlabel2`><`rpm`> ... : This command sets the number of speed of each motor in the motion planner, accepts uint (ex. "SPEED x,100 y,200 z,50")
+        
+        3. STANDBY <`motorlabel1`>,<`true`> <`motorlabel2`><`false`> ... : This command sets the number of speed of each motor in the motion planner, accepts bool or 1/0 (ex. "STANDBY x,1 y,0 z,true")
     */
 
     printf("Done!\n");
@@ -175,8 +179,8 @@ All kinds of feedback and contributions are welcome.
     - Current Functionality is to receive commands from Serial USB 
     - Concurrent operation with the loop_forever() method (blocking)
     - USB Serial Command list:
-        1. MOVE <`motorlabel1`>,<`revolutions`> <`motorlabel2`><`revolutions`> ... : This command sets the number of revolutions that each motor in the motion planner should make, currently only accepts int (ex. "MOVE x,100 y,-100 z,10")
-        2. SPEED (in progress)
-        3. STANDBY (in progress)
+        1. MOVE <`motorlabel1`>,<`revolutions`> <`motorlabel2`><`revolutions`> ... : This command sets the number of revolutions that each motor in the motion planner should make, accepts double (ex. "MOVE x,100 y,-100 z,10")
+        2. SPEED <`motorlabel1`>,<`rpm`> <`motorlabel2`><`rpm`> ... : This command sets the number of speed of each motor in the motion planner, accepts uint (ex. "SPEED x,100 y,200 z,50")
+        3. STANDBY <`motorlabel1`>,<`true`> <`motorlabel2`><`false`> ... : This command sets the number of speed of each motor in the motion planner, accepts bool or 1/0 (ex. "STANDBY x,1 y,0 z,true")
         4. POSITION (in progress)
-        4. HOME (in progress)
+        5. HOME (in progress)

--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -31,6 +31,7 @@ class MotionPlanner{
         void register_commands_();
         bool is_integer_(const std::string& s);
         bool is_bool_(const std::string& s);
+        bool is_float_(const std::string& s);
         bool sto_bool_(const std::string& s);
 
 

--- a/include/MotionPlanner.h
+++ b/include/MotionPlanner.h
@@ -30,6 +30,8 @@ class MotionPlanner{
 
         void register_commands_();
         bool is_integer_(const std::string& s);
+        bool is_bool_(const std::string& s);
+        bool sto_bool_(const std::string& s);
 
 
         std::queue<std::function<void()>> action_queue_;

--- a/include/StepperMotor.h
+++ b/include/StepperMotor.h
@@ -26,7 +26,7 @@ class StepperMotor {
                      uint32_t steps_per_rev,
                      uint32_t default_speed=200); //in rpm
 
-        void revolve(int32_t revolutions=1);
+        void revolve(double revolutions=1.0);
         void set_speed(uint32_t rpm=200);
         void home();
         std::tuple<int32_t, double>  update_position();

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -118,11 +118,8 @@ void MotionPlanner::register_commands_(){
         /*This command parses commands from serial with this format:
             "MOVE X,10 Y,100 Z,-100"
         */
-
         std::string token;
         std::unordered_map<std::string, int32_t> command_dict;
-
-
         while (iss >> token){
 
             if (token.length() <2 ) {continue;}
@@ -130,7 +127,6 @@ void MotionPlanner::register_commands_(){
             std::istringstream command_stream(token);
             std::string label, value_str;
             
-
             if(std::getline(command_stream, label, ',') && std::getline(command_stream, value_str)){
 
                 if(stepper_motors_.find(label) == stepper_motors_.end()){
@@ -150,7 +146,6 @@ void MotionPlanner::register_commands_(){
                 LOG_WARN("Invalid token: %s\n", token.c_str());
                 continue;
             }
-
         }
 
         if(!command_dict.empty()){
@@ -168,19 +163,139 @@ void MotionPlanner::register_commands_(){
             LOG_WARN("No valid actions in MOVE command\n");
         }
 
+    };
+
+    
+    command_handlers_["SPEED"] = [&](std::istringstream& iss) {
+        /*This command parses commands from serial with this format:
+            "SPEED X,200 Y,100 Z,300" will take negative values as absolute value
+        */
+        std::string token;
+        std::unordered_map<std::string, uint32_t> command_dict;
+
+        while(iss>>token){
+
+            if (token.length() <2 ) {continue;}
+
+            std::istringstream command_stream(token);
+            std::string label, value_str;
+
+            if(std::getline(command_stream, label, ',') && std::getline(command_stream, value_str)){
+                if(stepper_motors_.find(label) == stepper_motors_.end()){
+                    LOG_WARN("Unknown motor: %s\n",label.c_str());
+                    continue;
+                }
+
+                if (value_str.empty() || (!is_integer_(value_str))) {
+                    LOG_WARN("Invalid input: %s\n", value_str.c_str());
+                    continue;
+                }
+
+                uint32_t value = static_cast<uint32_t>(std::abs(std::stoi(value_str)));
+                command_dict[label] = value;
+
+            }else{
+                LOG_WARN("Invalid token: %s\n", token.c_str());
+                continue;
+            }
+        }
+
+        if(!command_dict.empty()){
+
+            action_queue_.push([command_dict, this](){
+
+                for(const auto& [label, value] : command_dict){
+
+                    stepper_motors_[label]->set_speed(value);
+                    LOG_INFO("Added to Queue: SPEED %s -> %d rpm\n", label.c_str(), value);
+
+                }
+            });
+        }else{
+            LOG_WARN("No valid actions in SPEED command\n");
+        }
 
     };
 
-    // command_handlers_["SPEED"] = [&](std::istringstream& iss) {
+    command_handlers_["STANDBY"] = [&](std::istringstream& iss) {
+        /*This command parses commands from serial with this format:
+            "STANDBY X,0 Y,1 Z,0"
+        */
+        std::string token;
+        std::unordered_map<std::string, bool> command_dict;
 
-    // };
+        while(iss>>token){
 
+            if (token.length() <2 ) {continue;}
+
+            std::istringstream command_stream(token);
+            std::string label, value_str;
+
+            if(std::getline(command_stream, label, ',') && std::getline(command_stream, value_str)){
+                if(stepper_motors_.find(label) == stepper_motors_.end()){
+                    LOG_WARN("Unknown motor: %s\n",label.c_str());
+                    continue;
+                }
+
+                if (value_str.empty() || (!is_bool_(value_str))) {
+                    LOG_WARN("Invalid input: %s\n", value_str.c_str());
+                    continue;
+                }
+
+                bool value = sto_bool_(value_str);
+                command_dict[label] = value;
+
+            }else{
+                LOG_WARN("Invalid token: %s\n", token.c_str());
+                continue;
+            }
+        }
+
+        if(!command_dict.empty()){
+
+            action_queue_.push([command_dict, this](){
+
+                for(const auto& [label, value] : command_dict){
+
+                    stepper_motors_[label]->set_standbyMode(value);
+                    LOG_INFO("Added to Queue: STANDBY %s -> %s\n", label.c_str(), value ? "enabled": "disabled");
+
+                }
+            });
+        }else{
+            LOG_WARN("No valid actions in STANDBY command\n");
+        }
+
+    };
 
 }
 
+
+
+
+/*Helper functions*/
 
 bool MotionPlanner::is_integer_(const std::string& s) {
     if (s.empty()) return false;
     size_t start = (s[0] == '-' ? 1 : 0);
     return std::all_of(s.begin() + start, s.end(), ::isdigit);
+}
+
+bool MotionPlanner::is_bool_(const std::string& s) {
+    std::string lower;
+    std::transform(s.begin(), s.end(), std::back_inserter(lower), ::tolower);
+
+    return (lower == "true" || lower == "false" || s == "1" || s == "0");
+}
+
+bool MotionPlanner::sto_bool_(const std::string& s) {
+    std::string lower;
+    std::transform(s.begin(), s.end(), std::back_inserter(lower), ::tolower);
+
+    if (lower == "true" || lower == "1")  return true;
+    if (lower == "false" || lower == "0") return false;
+
+    LOG_ERROR("Invalid boolean string: %s", s.c_str());
+
+    return false;
 }

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -118,7 +118,7 @@ void MotionPlanner::register_commands_(){
         /*This command parses commands from serial with this format:
             "MOVE X,10 Y,100 Z,-100"
         */
-        std::string full_line = std::string(std::istreambuf_iterator<char>(iss), {});
+        std::string full_line = iss.str().substr(iss.tellg());
         std::string token;
         std::unordered_map<std::string, int32_t> command_dict;
         while (iss >> token){
@@ -174,7 +174,7 @@ void MotionPlanner::register_commands_(){
         /*This command parses commands from serial with this format:
             "SPEED X,200 Y,100 Z,300" will take negative values as absolute value
         */
-        std::string full_line = std::string(std::istreambuf_iterator<char>(iss), {});
+        std::string full_line = iss.str().substr(iss.tellg());
         std::string token;
         std::unordered_map<std::string, uint32_t> command_dict;
 
@@ -229,7 +229,7 @@ void MotionPlanner::register_commands_(){
         /*This command parses commands from serial with this format:
             "STANDBY X,0 Y,1 Z,0"
         */
-        std::string full_line = std::string(std::istreambuf_iterator<char>(iss), {});
+        std::string full_line = iss.str().substr(iss.tellg());
         std::string token;
         std::unordered_map<std::string, bool> command_dict;
 

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -118,6 +118,7 @@ void MotionPlanner::register_commands_(){
         /*This command parses commands from serial with this format:
             "MOVE X,10 Y,100 Z,-100"
         */
+        std::string full_line = std::string(std::istreambuf_iterator<char>(iss), {});
         std::string token;
         std::unordered_map<std::string, int32_t> command_dict;
         while (iss >> token){
@@ -155,12 +156,15 @@ void MotionPlanner::register_commands_(){
                 for(const auto& [label, value] : command_dict){
 
                     stepper_motors_[label]->revolve(value);
-                    LOG_INFO("Added to Queue: MOVE %s -> %d revolutions\n", label.c_str(), value);
+                    LOG_INFO("Action: MOVE %s -> %d revolutions\n", label.c_str(), value);
 
                 }
             });
+
+            LOG_INFO("Added to Queue: MOVE %s\n", full_line.c_str());
+
         }else{
-            LOG_WARN("No valid actions in MOVE command\n");
+            LOG_WARN("No valid actions in MOVE command: %s\n", full_line.c_str());
         }
 
     };
@@ -170,6 +174,7 @@ void MotionPlanner::register_commands_(){
         /*This command parses commands from serial with this format:
             "SPEED X,200 Y,100 Z,300" will take negative values as absolute value
         */
+        std::string full_line = std::string(std::istreambuf_iterator<char>(iss), {});
         std::string token;
         std::unordered_map<std::string, uint32_t> command_dict;
 
@@ -207,12 +212,15 @@ void MotionPlanner::register_commands_(){
                 for(const auto& [label, value] : command_dict){
 
                     stepper_motors_[label]->set_speed(value);
-                    LOG_INFO("Added to Queue: SPEED %s -> %d rpm\n", label.c_str(), value);
+                    LOG_INFO("Action: SPEED %s -> %d rpm\n", label.c_str(), value);
 
                 }
             });
+
+            LOG_INFO("Added to Queue: SPEED %s\n", full_line.c_str());
+
         }else{
-            LOG_WARN("No valid actions in SPEED command\n");
+            LOG_WARN("No valid actions in SPEED command: %s\n", full_line.c_str());
         }
 
     };
@@ -221,6 +229,7 @@ void MotionPlanner::register_commands_(){
         /*This command parses commands from serial with this format:
             "STANDBY X,0 Y,1 Z,0"
         */
+        std::string full_line = std::string(std::istreambuf_iterator<char>(iss), {});
         std::string token;
         std::unordered_map<std::string, bool> command_dict;
 
@@ -258,12 +267,14 @@ void MotionPlanner::register_commands_(){
                 for(const auto& [label, value] : command_dict){
 
                     stepper_motors_[label]->set_standbyMode(value);
-                    LOG_INFO("Added to Queue: STANDBY %s -> %s\n", label.c_str(), value ? "enabled": "disabled");
+                    LOG_INFO("Action: STANDBY %s -> %s\n", label.c_str(), value ? "enabled": "disabled");
 
                 }
             });
+            LOG_INFO("Added to Queue: STANDBY %s\n", full_line.c_str());
+
         }else{
-            LOG_WARN("No valid actions in STANDBY command\n");
+            LOG_WARN("No valid actions in STANDBY command: %s\n", full_line.c_str());
         }
 
     };

--- a/src/MotionPlanner.cpp
+++ b/src/MotionPlanner.cpp
@@ -116,11 +116,11 @@ void MotionPlanner::register_commands_(){
 
     command_handlers_["MOVE"] = [&](std::istringstream& iss) {
         /*This command parses commands from serial with this format:
-            "MOVE X,10 Y,100 Z,-100"
+            "MOVE X,10.0 Y,100.0 Z,-100.0"
         */
         std::string full_line = iss.str().substr(iss.tellg());
         std::string token;
-        std::unordered_map<std::string, int32_t> command_dict;
+        std::unordered_map<std::string, double> command_dict;
         while (iss >> token){
 
             if (token.length() <2 ) {continue;}
@@ -135,12 +135,12 @@ void MotionPlanner::register_commands_(){
                     continue;
                 }
 
-                if (value_str.empty() || (!is_integer_(value_str))) {
+                if (value_str.empty() || (!is_float_(value_str))) {
                     LOG_WARN("Invalid input: %s\n", value_str.c_str());
                     continue;
                 }
 
-                int32_t value = std::stoi(value_str);
+                double value = std::stod(value_str);
                 command_dict[label] = value;
 
             }else{
@@ -156,7 +156,7 @@ void MotionPlanner::register_commands_(){
                 for(const auto& [label, value] : command_dict){
 
                     stepper_motors_[label]->revolve(value);
-                    LOG_INFO("Action: MOVE %s -> %d revolutions\n", label.c_str(), value);
+                    LOG_INFO("Action: MOVE %s -> %0.2f revolutions\n", label.c_str(), value);
 
                 }
             });
@@ -309,4 +309,14 @@ bool MotionPlanner::sto_bool_(const std::string& s) {
     LOG_ERROR("Invalid boolean string: %s", s.c_str());
 
     return false;
+}
+
+bool MotionPlanner::is_float_(const std::string& s) {
+    if (s.empty()) return false;
+
+    std::istringstream iss(s);
+    float val;
+    iss >> std::noskipws >> val;
+
+    return !iss.fail() && iss.eof();
 }

--- a/src/StepperMotor.cpp
+++ b/src/StepperMotor.cpp
@@ -24,17 +24,17 @@ StepperMotor::StepperMotor (std::string label,
 
 }
 
-void StepperMotor::revolve(int32_t revolutions){
+void StepperMotor::revolve(double revolutions){
     
     bool direction = revolutions>=0 ? true:false;
     driver_.set_direction(direction);
     
     LOG_DEBUG("%s direction set to: %s\n", label_.c_str(), direction ? "CW" : "CCW");
     
-    uint32_t steps = std::abs(revolutions)*steps_per_rev_;
+    uint32_t steps = static_cast<uint32_t>(std::round(std::abs(revolutions) * steps_per_rev_));
     driver_.step_for(steps);
     
-    LOG_DEBUG("%s set for: %d revolutions \n", label_.c_str(), std::abs(revolutions));
+    LOG_DEBUG("%s set for: %.2f revolutions\n", label_.c_str(), std::abs(revolutions));
 
 }
 

--- a/src/TB67S128FTG.cpp
+++ b/src/TB67S128FTG.cpp
@@ -114,9 +114,9 @@ bool TB67S128FTG::step_pulse(){
             last_time_update_us_ = time_now;
             steps_--;
 
-            if(dir_state_){
+            if(dir_state_ && !stby_state_){
                 step_tracker_++;
-            } else if (!dir_state_){
+            } else if (!dir_state_ && !stby_state_){
                 step_tracker_--;
             }
             


### PR DESCRIPTION
- Added the following:
        2. SPEED <`motorlabel1`>,<`rpm`> <`motorlabel2`><`rpm`> ... : This command sets the number of speed of each motor in the motion planner, accepts uint (ex. "SPEED x,100 y,200 z,50")
        3. STANDBY <`motorlabel1`>,<`true`> <`motorlabel2`><`false`> ... : This command sets the number of speed of each motor in the motion planner, accepts bool or 1/0 (ex. "STANDBY x,1 y,0 z,true")

- Fix logging and updating position when in standby mode

- revolve functions and calls to it accepts double precision floating point input